### PR TITLE
添加了命令行参数支持（-h帮助、指定config和lastdata路径）并实现运行中按回车切换代理IP功能。

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,23 @@ deadpool代理池工具，可从**hunter**、**quake**、**fofa**等**网络空�
 
 ### 0x03 配置使用
 
+**命令行参数**
+
+Deadpool支持以下命令行参数：
+
+- `-h, --help`：显示帮助信息
+- `-c, --config <path>`：指定配置文件路径（默认：config.toml）
+- `-l, --lastdata <path>`：指定lastdata文件路径（默认：lastData.txt）。使用此选项时，不会重新从网络空间获取代理，只使用指定的文件中的代理。
+
+示例：
+```
+./deadpool -c custom_config.toml -l my_proxies.txt
+```
+
+**运行中切换代理IP**
+
+在程序运行过程中，您可以通过按回车键切换到下一个可用代理IP。每次切换后，程序会显示当前使用的代理IP及其在代理列表中的位置。
+
 **burp中配置**
 
 <img src="images/burp.png" style="zoom: 28%;" width="65%" height="65%"/>
@@ -231,4 +248,3 @@ exit 0
 完整目录结构：
 
 ![alt text](./images/struct.png)
-

--- a/utils/globals.go
+++ b/utils/globals.go
@@ -13,6 +13,22 @@ var (
 	semaphore     chan struct{}
 )
 
+// GetCurrentProxyIndex 获取当前代理索引
+func GetCurrentProxyIndex() int {
+	mu.Lock()
+	defer mu.Unlock()
+	return proxyIndex
+}
+
+// SetNextProxyIndex 设置下一个代理索引
+func SetNextProxyIndex() {
+	mu.Lock()
+	defer mu.Unlock()
+	if len(EffectiveList) > 0 {
+		proxyIndex = (proxyIndex + 1) % len(EffectiveList)
+	}
+}
+
 func Banner() {
 	banner := `
    ____                        __                          ___      


### PR DESCRIPTION
支持-h进行参数帮助 支持指定config地址 指定lastdata地址(且指定lastdata.txt的时候就不需要再去重新获取socks5代理)
在程序运行过程中，用户可以通过按回车键切换到下一个可用代理IP
每次切换后，程序会显示当前使用的代理IP及其在代理列表中的位置